### PR TITLE
Fix crashing Draw Tool plugin

### DIFF
--- a/iitc_plugin_nearby_portals.user.js
+++ b/iitc_plugin_nearby_portals.user.js
@@ -13,7 +13,7 @@
 // ==/UserScript==
 (function() {
   function wrapper() {
-    if (typeof window.plugin !== 'object') window.plugin = {};
+    if(typeof window.plugin !== 'function') window.plugin = function() {};
     var p = window.plugin.nearbyPortals = { defaultRadiusKm: 1.0 };
 
     // Consolidated CSS for dialog content and button styles


### PR DESCRIPTION
```
if(typeof window.plugin !== 'function') window.plugin = function() {};
```
this is a part of IITC plugin template.